### PR TITLE
docs: apply Xsolla GitHub repository standard files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+> [!CAUTION]
+> ## ⚠️ This repository is deprecated — use Xsolla SDK 3 instead
+>
+> **This is a legacy Xsolla Pay Station iframe embed widget using deprecated CDN paths and API and is no longer actively maintained or updated.**
+> If you arrived here from a web search, do not use this repository for new integrations.
+>
+> **The current recommended version is [Xsolla SDK 3](https://developers.xsolla.com/sdk/)**, which provides:
+> - ✅ Up-to-date authentication and payment integrations across modern platforms
+> - ✅ Active development with ongoing bug fixes, new features, and security updates
+> - ✅ 1000+ payment methods across 200+ countries and territories
+> - ✅ Modern payment UI components and current Pay Station integration
+>
+> **Get started with SDK 3:**
+> | Resource | Link |
+> |---|---|
+> | 📖 SDK 3 Documentation | https://developers.xsolla.com/sdk/ |
+> | 🔭 SDK Explorer (try before you code) | https://developers.xsolla.com/sdk/demo/ |
+>
+> _Do not start new integrations on this repository._
+
 # Xsolla Pay Station Widget
 
 ![License](https://img.shields.io/github/license/xsolla/paystation-embed)


### PR DESCRIPTION
Applies the Xsolla GitHub Repository Standard to this repository, including a prominent SDK 3 deprecation banner in the README.

This repo uses the legacy Pay Station iframe embed widget with deprecated CDN paths. The banner redirects developers who land here via web search to Xsolla SDK 3 at https://developers.xsolla.com/sdk/.